### PR TITLE
Upgrading docker compose version in CI workflow to Ubuntu (latest) requirement.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,5 @@ jobs:
       
       - name: Test
         run: |
-          docker-compose -f docker-compose.test.yaml up --build --no-deps --abort-on-container-exit --exit-code-from oaipmh
-          docker-compose -f docker-compose.test.yaml down
+          docker compose -f docker-compose.test.yaml up --build --no-deps --abort-on-container-exit --exit-code-from oaipmh
+          docker compose -f docker-compose.test.yaml down


### PR DESCRIPTION
Starting end of July, docker composed was upgraded from V1 to V2 in Ubuntu 2204 latest. 
Ubuntu lastest changed from
[20240721.1.0](https://github.com/actions/runner-images/blob/ubuntu22/20240721.1/images/ubuntu/Ubuntu2204-Readme.md)  to 
[20240730.2.0](https://github.com/actions/runner-images/blob/ubuntu22/20240730.2/images/ubuntu/Ubuntu2204-Readme.md)
docker compose moved from V1 to V2 with this [issue](https://github.com/actions/runner-images/issues/9692)
So we need to replace 'docker-compose' by 'docker compose' in the CI Workflow.