### PR TITLE
fix: list identifiers verb issue

### DIFF
--- a/src/providers/scicat-provider/dao/scicat-be-dao.ts
+++ b/src/providers/scicat-provider/dao/scicat-be-dao.ts
@@ -87,9 +87,7 @@ export class SciCatBEConnector {
     };
     return this.publishedDataApi.publishedDataControllerFindAll(filters)
       .then( (res) => {
-        return res.map((item) =>{
-          return item.doi;
-        })
+        return res;
       });
   }
 

--- a/src/providers/scicat-provider/repository/openaire-mapper.ts
+++ b/src/providers/scicat-provider/repository/openaire-mapper.ts
@@ -12,7 +12,7 @@ export class OpenaireMapper extends ProviderDCMapper {
    * @returns {string}
    */
   private setTimeZoneOffset(record: any): string {
-    const date = new Date(record.updatedAt);
+    const date = new Date(record.updatedAt || record.createdAt);
     const timeZoneCorrection = new Date(
       date.getTime() + date.getTimezoneOffset() * -60000
     );


### PR DESCRIPTION
This PR fixes the issues with verb `ListIdentifier` which was returning a 500 error.