### PR TITLE
Release 2025/08 16.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-slim
 
 WORKDIR /home/node/app
 


### PR DESCRIPTION
Switched base image from alpine to slim because esbuild’s ARM64 binary needs the glibc loader that Alpine (musl) lacks, so Slim (glibc) works out of the box at the cost of a larger image, while Alpine stays lean but requires extra compatibility hacks; this is a temporary workaround