### PR TITLE
fix: return all records with default pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "GPL-3.0",
       "dependencies": {
-        "@scicatproject/scicat-sdk-ts-fetch": "^4.17.0",
+        "@scicatproject/scicat-sdk-ts-fetch": "^4.27.0",
         "@types/node": "^20.17.30",
         "bluebird": "^3.7.2",
         "body-parser": "^1.20.3",
@@ -774,9 +774,9 @@
       }
     },
     "node_modules/@scicatproject/scicat-sdk-ts-fetch": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@scicatproject/scicat-sdk-ts-fetch/-/scicat-sdk-ts-fetch-4.17.0.tgz",
-      "integrity": "sha512-+TnsHNK5e6K9qN06b4aSUj/guFm/j9GwuqXLc02FZAyTTaaCKYEVdmsMLZb1vbgC6v0sxZb9hevR5e0qWxbpUg=="
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@scicatproject/scicat-sdk-ts-fetch/-/scicat-sdk-ts-fetch-4.27.0.tgz",
+      "integrity": "sha512-1BvpTEVA1DgfrS/renDM+gs2PM34On00sOLPvUQm/OR3gOIzNlw8g7Sl3ceoyH2hVbMNlXfqRijMtW7646a+EQ=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "node build.js && mocha --exit"
   },
   "dependencies": {
-    "@scicatproject/scicat-sdk-ts-fetch": "^4.17.0",
+    "@scicatproject/scicat-sdk-ts-fetch": "^4.27.0",
     "@types/node": "^20.17.30",
     "bluebird": "^3.7.2",
     "body-parser": "^1.20.3",

--- a/src/providers/scicat-provider/dao/scicat-be-dao.ts
+++ b/src/providers/scicat-provider/dao/scicat-be-dao.ts
@@ -12,6 +12,7 @@ export class SciCatBEConnector {
   public scicatUrl: string;
   public publishedDataCount: number;
   private aconf: AppConfiguration;
+  private MAX_LIMIT = 5000;
 
   private constructor() {
 
@@ -69,7 +70,7 @@ export class SciCatBEConnector {
       filter: JSON.stringify({
         where: { status: "registered" },
         fields: { thumbnail: 0 },
-        limits: { limit: totalRecords },
+        limits: { limit: Math.min(totalRecords?.count ?? 100, this.MAX_LIMIT) },
       }),
     };
     return this.publishedDataApi.publishedDataControllerFindAllV3(filters);
@@ -86,7 +87,7 @@ export class SciCatBEConnector {
       filter: JSON.stringify({
         where: { status: "registered" },
         fields: { thumbnail: 0 },
-        limits: { limit: totalRecords },
+        limits: { limit: Math.min(totalRecords?.count ?? 100, this.MAX_LIMIT) },
       }),
     };
     return this.publishedDataApi.publishedDataControllerFindAllV3(filters)

--- a/src/providers/scicat-provider/dao/scicat-be-dao.ts
+++ b/src/providers/scicat-provider/dao/scicat-be-dao.ts
@@ -35,14 +35,14 @@ export class SciCatBEConnector {
       this.publishedDataApi = new PublishedDataApi(apiConfig);
 
       this.publishedDataApi.publishedDataControllerCountV3()
-        .then( (res) =>{
+        .then((res) => {
           this.publishedDataCount = res.count;
         })
-        .catch( (error) => {
+        .catch((error) => {
           logger.error("Failed to connect to SciCat :", error.message);
           throw error;
         });
-      
+
     }
   }
 
@@ -63,12 +63,14 @@ export class SciCatBEConnector {
    * @param parameters
    * @returns {Promise<any>}
    */
-  public recordsQuery(parameters: any,): Promise<any> {
+  public async recordsQuery(parameters: any,): Promise<any> {
+    const totalRecords = await this.publishedDataApi.publishedDataControllerCountV3();
     const filters: PublishedDataControllerFindAllV3Request = {
       filter: JSON.stringify({
-        "where":{"status":"registered"},
+        where: { status: "registered" },
+        fields: { thumbnail: 0 },
+        limits: { limit: totalRecords },
       }),
-      fields: "{}",
     };
     return this.publishedDataApi.publishedDataControllerFindAllV3(filters);
   }
@@ -78,15 +80,17 @@ export class SciCatBEConnector {
    * @param parameters
    * @returns {Promise<any>}
    */
-  public identifiersQuery(parameters: any): Promise<any> {
+  public async identifiersQuery(parameters: any): Promise<any> {
+    const totalRecords = await this.publishedDataApi.publishedDataControllerCountV3();
     const filters: PublishedDataControllerFindAllV3Request = {
       filter: JSON.stringify({
-        "where":{"status":"registered"},
+        where: { status: "registered" },
+        fields: { thumbnail: 0 },
+        limits: { limit: totalRecords },
       }),
-      fields: "{}",
     };
     return this.publishedDataApi.publishedDataControllerFindAllV3(filters)
-      .then( (res) => {
+      .then((res) => {
         return res;
       });
   }


### PR DESCRIPTION
the new BE introduces default pagination which cuts the oaipmh records. This PR returns them all with a limit. It requires a new sdk version